### PR TITLE
🌿 Upgrade Fern CLI 

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "seam",
-  "version": "0.11.12-rc1"
+  "version": "0.13.0-rc0"
 }


### PR DESCRIPTION
This version of the Fern CLI handles `oneOf` imports from OpenAPI better so that the generated SDKs compile. 