### PR TITLE
:herb: Upgrade fern-go-sdk and return resources directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Check Fern API is valid
         run: fern check
 
-  fern-release: 
+  fern-generate-java:
     needs: fern-check
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/java@')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -25,14 +25,40 @@ jobs:
 
       - name: Setup node
         uses: actions/setup-node@v3
-      
+
       - name: Download Fern
         run: npm install -g fern-api
 
-      - name: Release SDKs
+      - name: Release Java SDK
         env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          tag=${{ github.ref_name }}
+          prefix="java@"
+          SDK_VERSION="${tag#$prefix}"
+          fern generate --group java-sdk --version "$SDK_VERSION" --log-level debug
+
+  fern-generate-go:
+    needs: fern-check
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/go@')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Release Go SDK
+        env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --group publish --version ${{ github.ref_name }} --log-level debug
+        run: |
+          tag=${{ github.ref_name }}
+          prefix="go@"
+          SDK_VERSION="${tag#$prefix}"
+          fern generate --group go-sdk --version "$SDK_VERSION" --log-level debug

--- a/fern/definition/accessCodes.yml
+++ b/fern/definition/accessCodes.yml
@@ -38,6 +38,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesCreateResponse
+        property: access_code
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -73,6 +74,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesCreateMultipleResponse
+        property: access_codes
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -94,6 +96,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesDeleteResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -116,6 +119,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesGetResponse
+        property: access_code
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -135,6 +139,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesListResponse
+        property: access_codes
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -152,6 +157,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesPullBackupAccessCodeResponse
+        property: backup_access_code
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -189,6 +195,7 @@ service:
       response:
         docs: OK
         type: root.AccessCodesUpdateResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/actionAttempts.yml
+++ b/fern/definition/actionAttempts.yml
@@ -20,6 +20,7 @@ service:
       response:
         docs: OK
         type: root.ActionAttemptsGetResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -38,6 +39,7 @@ service:
       response:
         docs: OK
         type: root.ActionAttemptsListResponse
+        property: action_attempts
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/clientSessions.yml
+++ b/fern/definition/clientSessions.yml
@@ -25,6 +25,7 @@ service:
       response:
         docs: OK
         type: root.ClientSessionsCreateResponse
+        property: client_session
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -42,6 +43,7 @@ service:
       response:
         docs: OK
         type: root.ClientSessionsDeleteResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -62,6 +64,7 @@ service:
       response:
         docs: OK
         type: root.ClientSessionsGetResponse
+        property: client_session
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -84,6 +87,7 @@ service:
       response:
         docs: OK
         type: root.ClientSessionsListResponse
+        property: client_sessions
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/connectWebviews.yml
+++ b/fern/definition/connectWebviews.yml
@@ -34,6 +34,7 @@ service:
       response:
         docs: OK
         type: root.ConnectWebviewsCreateResponse
+        property: connect_webview
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -51,6 +52,7 @@ service:
       response:
         docs: OK
         type: root.ConnectWebviewsDeleteResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -68,6 +70,7 @@ service:
       response:
         docs: OK
         type: root.ConnectWebviewsGetResponse
+        property: connect_webview
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/connectedAccounts.yml
+++ b/fern/definition/connectedAccounts.yml
@@ -20,6 +20,7 @@ service:
       response:
         docs: OK
         type: root.ConnectedAccountsDeleteResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -35,6 +36,7 @@ service:
       response:
         docs: OK
         type: root.ConnectedAccountsGetResponse
+        property: connected_account
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -47,6 +49,7 @@ service:
       response:
         docs: OK
         type: root.ConnectedAccountsListResponse
+        property: connected_accounts
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/devices.yml
+++ b/fern/definition/devices.yml
@@ -20,6 +20,7 @@ service:
       response:
         docs: OK
         type: root.DevicesDeleteResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -40,6 +41,7 @@ service:
       response:
         docs: OK
         type: root.DevicesGetResponse
+        property: device
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -74,6 +76,7 @@ service:
       response:
         docs: OK
         type: root.DevicesListResponse
+        property: devices
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -92,6 +95,7 @@ service:
       response:
         docs: OK
         type: root.DevicesListDeviceProvidersResponse
+        property: device_providers
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -117,6 +121,7 @@ service:
       response:
         docs: OK
         type: root.DevicesUpdateResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/events.yml
+++ b/fern/definition/events.yml
@@ -25,6 +25,7 @@ service:
       response:
         docs: OK
         type: root.EventsGetResponse
+        property: event
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -59,6 +60,7 @@ service:
       response:
         docs: OK
         type: root.EventsListResponse
+        property: events
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/locks.yml
+++ b/fern/definition/locks.yml
@@ -23,6 +23,7 @@ service:
       response:
         docs: OK
         type: root.LocksGetResponse
+        property: device
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -57,6 +58,7 @@ service:
       response:
         docs: OK
         type: root.LocksListResponse
+        property: devices
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -76,6 +78,7 @@ service:
       response:
         docs: OK
         type: root.LocksLockDoorResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -95,6 +98,7 @@ service:
       response:
         docs: OK
         type: root.LocksUnlockDoorResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/noiseSensors/noiseThresholds.yml
+++ b/fern/definition/noiseSensors/noiseThresholds.yml
@@ -30,6 +30,7 @@ service:
       response:
         docs: OK
         type: root.NoiseThresholdsCreateResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -50,6 +51,7 @@ service:
       response:
         docs: OK
         type: root.NoiseThresholdsDeleteResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -67,6 +69,7 @@ service:
       response:
         docs: OK
         type: root.NoiseThresholdsGetResponse
+        property: noise_threshold
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -84,6 +87,7 @@ service:
       response:
         docs: OK
         type: root.NoiseThresholdsListResponse
+        property: noise_thresholds
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -114,6 +118,7 @@ service:
       response:
         docs: OK
         type: root.NoiseThresholdsUpdateResponse
+        property: action_attempt
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/thermostats.yml
+++ b/fern/definition/thermostats.yml
@@ -23,6 +23,7 @@ service:
       response:
         docs: OK
         type: root.ThermostatsGetResponse
+        property: thermostat
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -46,6 +47,7 @@ service:
       response:
         docs: OK
         type: root.ThermostatsHeatResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -80,6 +82,7 @@ service:
       response:
         docs: OK
         type: root.ThermostatsListResponse
+        property: thermostats
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -99,6 +102,7 @@ service:
       response:
         docs: OK
         type: root.ThermostatsUpdateResponse
+        property: ok
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/definition/workspaces.yml
+++ b/fern/definition/workspaces.yml
@@ -15,6 +15,7 @@ service:
       response:
         docs: OK
         type: root.WorkspacesGetResponse
+        property: workspace
       errors:
         - root.BadRequestError
         - root.UnauthorizedError
@@ -27,6 +28,7 @@ service:
       response:
         docs: OK
         type: root.WorkspacesListResponse
+        property: workspaces
       errors:
         - root.BadRequestError
         - root.UnauthorizedError

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "seam",
-  "version": "0.15.0-rc27"
+  "version": "0.15.0-rc50"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,5 +1,5 @@
 groups:
-  publish:
+  java-sdk:
     generators:
       - name: fernapi/fern-java-sdk
         version: 0.5.8
@@ -10,11 +10,13 @@ groups:
           password: ${MAVEN_PASSWORD}
         github:
           repository: seamapi/java
-        config: 
+        config:
           client-class-name: Seam
-          custom-dependencies: 
+          custom-dependencies:
             - "testImplementation org.assertj:assertj-core:3.24.2"
+  go-sdk:
+    generators:
       - name: fernapi/fern-go-sdk
-        version: 0.0.14
+        version: 0.7.0
         github:
           repository: seamapi/go


### PR DESCRIPTION
This updates the Go SDK to use the latest release ([0.7.0](https://github.com/fern-api/fern-go/releases/tag/0.7.0)) and updates the Fern definition to use the new response `property` configuration so that the generated SDK returns the resource directly (rather than the full response wrapper).

This also splits out the `fern-release` CI job into two separate jobs so that the Go and Java SDKs are independently released by prefixing the release with `go@` or `java@`, respectively.