### PR TITLE
Update is_managed properties to be boolean

### DIFF
--- a/fern/definition/__package__.yml
+++ b/fern/definition/__package__.yml
@@ -597,7 +597,7 @@ types:
       status: literal<"set">
       created_at:
         type: SimulateCreateUnmanagedAccessCodeResponseAccessCodeOngoingCreatedAt
-      is_managed: string
+      is_managed: boolean
       starts_at:
         type: optional<string>
       ends_at:
@@ -617,7 +617,7 @@ types:
       status: literal<"set">
       created_at:
         type: SimulateCreateUnmanagedAccessCodeResponseAccessCodeTimeBoundCreatedAt
-      is_managed: string
+      is_managed: boolean
       starts_at:
         type: optional<string>
       ends_at:
@@ -660,7 +660,7 @@ types:
         type: optional<unknown>
       warnings:
         type: optional<unknown>
-      is_managed: string
+      is_managed: boolean
       starts_at:
         type: optional<datetime>
       ends_at:
@@ -695,7 +695,7 @@ types:
         type: optional<unknown>
       warnings:
         type: optional<unknown>
-      is_managed: string
+      is_managed: boolean
       starts_at:
         type: optional<datetime>
       ends_at:
@@ -880,7 +880,7 @@ types:
         type: optional<unknown>
       warnings:
         type: optional<unknown>
-      is_managed: string
+      is_managed: boolean
       starts_at:
         type: optional<datetime>
       ends_at:
@@ -1102,7 +1102,7 @@ types:
       warnings:
         type: list<DeviceWarningsItem>
       created_at: datetime
-      is_managed: string
+      is_managed: boolean
 
   DeviceCapabilitiesSupportedItem:
     enum:
@@ -1226,7 +1226,7 @@ types:
       warnings:
         type: list<UnmanagedDeviceWarningsItem>
       created_at: datetime
-      is_managed: string
+      is_managed: boolean
       properties:
         type: UnmanagedDeviceProperties
   

--- a/fern/definition/devices/unmanaged.yml
+++ b/fern/definition/devices/unmanaged.yml
@@ -51,7 +51,7 @@ service:
         body:
           properties:
             device_id: string
-            is_managed: string
+            is_managed: boolean
       response:
         docs: OK
         type: root.UnmanagedUpdateResponse


### PR DESCRIPTION
This updates the `is_managed` property on all relevant types to be `boolean` instead of `string`. This was discovered when testing against [`fake-seam-connect`](https://github.com/seamapi/fake-seam-connect).