### PR TITLE
Upgrade fern-go-sdk to 0.8.0

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -17,6 +17,6 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.7.0
+        version: 0.8.0
         github:
           repository: seamapi/go


### PR DESCRIPTION
This upgrades `fern-go-sdk` to the latest [0.8.0](https://github.com/fern-api/fern-go/releases/tag/0.8.0) release.