### PR TITLE
fix: add seam-workspace header

### DIFF
--- a/fern/definition/api.yml
+++ b/fern/definition/api.yml
@@ -10,6 +10,9 @@ auth-schemes:
     scheme: bearer
     token:
       name: api_key
+headers: 
+  Seam-Workspace: 
+    type: optional<string>
 default-environment: default
 environments:
   default: https://connect.getseam.com


### PR DESCRIPTION
This fixes the Fern generated clients to allow users to supply the `Seam-Workspace` header. 