### PR TITLE
fix: upgrade fern cli to 0.16.32

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "seam",
-  "version": "0.16.31"
+  "version": "0.16.32"
 }


### PR DESCRIPTION
In this upgrade, `is_managed` is correctly imported as a boolean instead of a string.