### PR TITLE
Upgrade go generator to `0.15.0`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -20,7 +20,9 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.9.3
+        version: 0.15.0 
         github:
           repository: seamapi/go
           mode: pull-request
+        config: 
+          includeLegacyClientOptions: true


### PR DESCRIPTION
In this PR, the Go generator is upgraded to support datetime serialization that follows RFC 3339 formats.